### PR TITLE
Iframe support

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -17,12 +17,24 @@
 if (!window.hashpassLoaded) {
   window.hashpassLoaded = true;
 
+  // Stores a document inside of which activeElement is located.
+  var activeDocument = document;
+
   // Register the message handler.
   chrome.runtime.onMessage.addListener(
     function(request, sender, sendResponse) {
       // Trims the attribute and converts it to lowercase.
       var normalizeAttr = function(attr) {
         return attr.replace(/^\s+|\s+$/g, '').toLowerCase();
+      };
+
+      // Checks if activeElement is inside iframe or not and returns correct document.
+      var getActiveDocument = function() {
+        var elem = document.activeElement;
+        if (normalizeAttr(elem.tagName) === normalizeAttr('iframe')) {
+          return elem.contentDocument;
+        }
+        return document;
       };
 
       // Returns whether elem is an input of type "password".
@@ -39,7 +51,8 @@ if (!window.hashpassLoaded) {
 
       // Check if a password field is selected.
       if (request.type === 'hashpassCheckIfPasswordField') {
-        if (isPasswordInput(document.activeElement)) {
+        activeDocument = getActiveDocument();
+        if (isPasswordInput(activeDocument.activeElement)) {
           sendResponse({ type: 'password' });
           return;
         }
@@ -49,8 +62,8 @@ if (!window.hashpassLoaded) {
 
       // Fill in the selected password field.
       if (request.type === 'hashpassFillPasswordField') {
-        if (isPasswordInput(document.activeElement)) {
-          document.activeElement.value = request.hash;
+        if (isPasswordInput(activeDocument.activeElement)) {
+          activeDocument.activeElement.value = request.hash;
           sendResponse({ type: 'close' });
           return;
         }

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
 
   "name": "Hashpass",
-  "description": "A simple, stateless password manager for Chrome.",
-  "version": "1.9.5",
+  "description": "A simple, stateless password manager.",
+  "version": "1.9.6",
   "permissions": [
     "activeTab"
   ],

--- a/popup.js
+++ b/popup.js
@@ -123,10 +123,9 @@ $(function() {
               // Register the update handler.
               $('#domain').bind('propertychange change keyup input paste', debouncedUpdate);
               $('#key').bind('propertychange change keyup input paste', debouncedUpdate);
+              // Update the hash right away.
+              debouncedUpdate();
             }
-
-            // Update the hash right away.
-            debouncedUpdate();
 
             // Focus the text field.
             $('#key').focus();


### PR DESCRIPTION
Hashpass now can properly detect selected password fields inside of iframes.
For example, login form on twitch.tv is located inside of an iframe and it wasn't possible to fill password automatically. Now it's no longer an issue.

Additionally, I moved debouncedUpdate() function inside of !passwordMode check so that it won't calculate a hash if password field was selected, because it should do so only when ENTER key is pressed.

Also removed mention of Chrome from description, since Opera supports Chrome extensions.
Version increment.